### PR TITLE
Install protobuf before travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,3 +6,8 @@ rust:
 matrix:
   allow_failures:
     - rust: nightly
+env: PROTOBUF_VERSION=3.1.0
+
+before_install:
+  - ./install-protobuf.sh
+  - PATH=/home/travis/bin:$PATH protoc --version

--- a/install-protobuf.sh
+++ b/install-protobuf.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+
+set -ex
+
+die() {
+    echo "$@" >&2
+    exit 1
+}
+
+test -n "$PROTOBUF_VERSION" || die "PROTOBUF_VERSION env var is undefined"
+
+case "$PROTOBUF_VERSION" in
+2*)
+    basename=protobuf-$PROTOBUF_VERSION
+    ;;
+3*)
+    basename=protobuf-cpp-$PROTOBUF_VERSION
+    ;;
+*)
+    die "unknown protobuf version: $PROTOBUF_VERSION"
+    ;;
+esac
+
+curl -sL https://github.com/google/protobuf/releases/download/v$PROTOBUF_VERSION/$basename.tar.gz | tar zx
+
+cd protobuf-$PROTOBUF_VERSION
+
+./configure --prefix=/home/travis && make -j2 && make install


### PR DESCRIPTION
Install script imported from https://github.com/stepancheg/rust-protobuf/blob/11d8f14cc21fc609c24c84ffe95b9567d89d2988/install-protobuf.sh

This addresses #9 that probably was mistakenly closed.